### PR TITLE
Chore: container 클래스 기본설정 변경

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,17 +8,6 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      container: {
-        center: true,
-        padding: {
-          DEFAULT: "1rem", // 기본 패딩
-          sm: "1.5rem", // sm 브레이크포인트에서 패딩
-          md: "2.5rem", // md 브레이크포인트에서 패딩
-          lg: "3rem", // lg 브레이크포인트에서 패딩
-          xl: "4rem", // xl 브레이크포인트에서 패딩
-          "2xl": "5rem", // 2xl 브레이크포인트에서 패딩
-        },
-      },
       colors: {
         primary: "#112211",
         secondary: "",
@@ -75,8 +64,45 @@ const config: Config = {
         pretendard: ["var(--font-[pretendard)", "sans-serif"],
       },
     },
+    screens: {
+      md: "768px",
+      xl: "1280px",
+    },
   },
-  plugins: [],
+  corePlugins: {
+    container: false,
+  },
+  plugins: [
+    function ({
+      addComponents,
+      theme,
+    }: {
+      addComponents: Function;
+      theme: Function;
+    }) {
+      const screens = theme("screens") as Record<string, string>;
+
+      addComponents({
+        ".container": {
+          width: "100%",
+          marginLeft: "auto",
+          marginRight: "auto",
+          paddingLeft: "1rem",
+          paddingRight: "1rem",
+          maxWidth: "none",
+          [`@media (min-width: ${screens.md})`]: {
+            paddingLeft: "1.5rem",
+            paddingRight: "1.5rem",
+          },
+          [`@media (min-width: ${screens.xl})`]: {
+            paddingLeft: "2.5rem",
+            paddingRight: "2.5rem",
+            maxWidth: "1280px",
+          },
+        },
+      });
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
<!-- PR 제목에 관련된 이슈 번호를 포함합니다 -->
<!-- 예시: Fix #23 - 프로젝트 규칙 논의 -->

## 관련 이슈 (Related Issues)
<!-- 이 PR이 해결하는 이슈 번호를 적습니다. -->
<!-- Closes, Fixes, Resolves 키워드를 사용합니다. -->
<!-- 예시: Fixes #23 -->
Fixes #

## 변경 사항 (Changes)
<!-- 이 PR에서 어떤 부분이 변경되었는지 상세히 설명합니다. -->
- 테일윈드에서 기본으로 제공하는 container 클래스에 대한 기본 속성을 저희 프로젝트에 맞도록 기본 설정하였습니다.

## 체크리스트 (Checklist)
<!-- PR을 완료하기 전에 확인해야 할 사항들을 체크리스트로 만듭니다. -->
- [x] 코드가 제대로 동작하는지 테스트함
- [x] 코드 컨벤션을 잘 지킴


## 추가 설명 (Additional Context)
<!-- 변경 사항 외에 추가로 필요한 설명이나 스크린샷 등을 첨부합니다. -->
<img width="532" alt="image" src="https://github.com/user-attachments/assets/21b65e57-b732-44d2-9a03-cf303a8f2aef">

### 문제
기본 설정 때문에 저희가 안쓰는 2xl, l, sm 등의 미디어 쿼리가 자동으로 작동하는 문제가 있었습니다.

### 발생
그때문에
<img width="254" alt="image" src="https://github.com/user-attachments/assets/be470e5d-3a86-4ff0-8057-86831709f84f">
이렇게 저희가 안쓰는 미디어 쿼리에 max-width 가 잡혀 원하는 화면의 넓이, 여백이 렌더링 되지않았습니다.

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/74c9de87-dc83-4c71-8ac5-ec2431f8a318">
또한 코드를 작성할 때에도 유틸리티 클래스를 생성해주어 사용에 혼란을 주었습니다.

### 해결

config 파일에
<img width="405" alt="image" src="https://github.com/user-attachments/assets/668ee81d-2032-4093-bced-b0e809c0b0e3">
각 분기점에 있는 기본속성들을 없애고 원하는 분기점에만 max-width를 부여하였습니다.
저희 프로젝트에 맞도록 기본, 태블릿, 데스크탑 이렇게 3가지의 분기만 가지도록 하였습니다.

<img width="212" alt="image" src="https://github.com/user-attachments/assets/f2ab09fa-d35f-4590-8003-417e11ae272a">

md, xl 제외하고는 자동으로 유틸리티 클래스를 생성하지 못하도록 하였습니다.

