### PR TITLE
Feat: #49 메인페이지 검색 기능 구현 - 여러가지 수정 필요

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Footer from "@app/components/Footer/Footer";
 import Header from "@app/components/Header/Header";
 
@@ -9,7 +10,9 @@ export default function AppLayout({
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
-      <main className="flex flex-grow flex-col">{children}</main>
+      <Suspense>
+        <main className="flex flex-grow flex-col">{children}</main>
+      </Suspense>
       <Footer />
     </div>
   );

--- a/src/app/(app)/mypage/activity-status/CalendarSection.tsx
+++ b/src/app/(app)/mypage/activity-status/CalendarSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
-import { getMonthlyReservationsStatus } from "@api/myactivity-status";
+import { getMonthlyReservationsStatus } from "@api/MyActivity-Status";
 import { DailyReservationsStatus } from "@customTypes/MyActivity-Status";
 import { useQuery } from "@tanstack/react-query";
 import "./Calendar.css";

--- a/src/app/(app)/mypage/layout.tsx
+++ b/src/app/(app)/mypage/layout.tsx
@@ -1,4 +1,4 @@
-import { getMyActivityList } from "@api/myactivity-status";
+import { getMyActivityList } from "@api/MyActivity-Status";
 import SideNavigation from "@app/components/SideNavigation/SideNavigation";
 // "next/headers" 에서 제공하는 {cookies}를 사용하면, server-side에서 data-fetching을 하려고 할 때, browser에 저장된 쿠키값에 접근할 수 있는 것 같습니다.
 import { cookies } from "next/headers";

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -35,21 +35,21 @@ export default function Home() {
 
   return (
     <>
-      <section>
-        <div className="relative flex h-[240px] w-full justify-center bg-[url('../../public/images/img_main_banner.png')] bg-cover bg-center md:h-[550px]">
-          <div className="relative -left-1/4 mt-[74px] flex flex-col gap-5 md:mt-[144px] xl:mt-[159px]">
-            <h1 className="text-[24px] font-bold leading-tight text-white md:text-[54px] xl:text-[68px]">
-              함께 배우면 즐거운
-              <br /> 스트릿 댄스
-            </h1>
-            <p className="text-[14px] font-bold leading-tight text-white md:text-[20px] xl:text-[24px]">{`${monthNum}월의 인기 체험 BEST 🔥`}</p>
+      <Suspense>
+        <section>
+          <div className="relative flex h-[240px] w-full justify-center bg-[url('../../public/images/img_main_banner.png')] bg-cover bg-center md:h-[550px]">
+            <div className="relative -left-1/4 mt-[74px] flex flex-col gap-5 md:mt-[144px] xl:mt-[159px]">
+              <h1 className="text-[24px] font-bold leading-tight text-white md:text-[54px] xl:text-[68px]">
+                함께 배우면 즐거운
+                <br /> 스트릿 댄스
+              </h1>
+              <p className="text-[14px] font-bold leading-tight text-white md:text-[20px] xl:text-[24px]">{`${monthNum}월의 인기 체험 BEST 🔥`}</p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <div>
-        <section className="container relative flex justify-center bg-none">
-          <Suspense>
+        <div>
+          <section className="container relative flex justify-center bg-none">
             <div className="absolute -top-14 w-full rounded-2xl bg-white px-6 py-9">
               <h2 className="mb-5 text-lg font-bold md:text-xl">
                 무엇을 체험하고 싶으신가요?
@@ -79,25 +79,25 @@ export default function Home() {
                 </button>
               </div>
             </div>
-          </Suspense>
-        </section>
-        {content ? (
-          <Suspense>
-            <SearchActivityResult />
-          </Suspense>
-        ) : (
-          <div>
-            <section>
-              <PopularActivityList />
-            </section>
-            <section className="container">
-              <Suspense>
-                <ActivityCardList />
-              </Suspense>
-            </section>
-          </div>
-        )}
-      </div>
+          </section>
+          {content ? (
+            <Suspense>
+              <SearchActivityResult />
+            </Suspense>
+          ) : (
+            <div>
+              <section>
+                <PopularActivityList />
+              </section>
+              <section className="container">
+                <Suspense>
+                  <ActivityCardList />
+                </Suspense>
+              </section>
+            </div>
+          )}
+        </div>
+      </Suspense>
     </>
   );
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -82,7 +82,9 @@ export default function Home() {
           </Suspense>
         </section>
         {content ? (
-          <SearchActivityResult />
+          <Suspense>
+            <SearchActivityResult />
+          </Suspense>
         ) : (
           <div>
             <section>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,11 +1,37 @@
 "use client";
 
 import { Suspense } from "react";
+import { useState, useCallback } from "react";
+import { MouseEvent } from "react";
 import ActivityCardList from "@app/components/MainPage/ActivityCardList";
 import PopularActivityList from "@app/components/MainPage/PopularActivityList";
+import SearchActivityResult from "@app/components/MainPage/SearchActivityResult";
+import Image from "next/image";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import BedIcon from "@icons/icon_search.svg";
 
 export default function Home() {
   const monthNum = new Date().getMonth() + 1;
+  const [keyword, setKeyword] = useState<string>("");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [content, setContent] = useState("");
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+      if (!value) params.delete(name);
+      return params.toString();
+    },
+    [searchParams],
+  );
+
+  const handleSearch = (e: MouseEvent<HTMLButtonElement>) => {
+    const { name } = e.target as HTMLButtonElement;
+    setContent(name);
+    router.push(pathname + "?" + createQueryString("keyword", String(keyword)));
+  };
 
   return (
     <>
@@ -20,21 +46,61 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <div className="container">
-        {/* 체험 검색 기능 필요 */}
-        <section>Search section</section>
-        <section>
-          {/* 인기 체험 구현 필요 */}
-          <PopularActivityList />
+
+      <div>
+        <section className="container relative flex justify-center bg-none">
+          <Suspense>
+            <div className="absolute -top-14 w-full rounded-2xl bg-white px-6 py-9">
+              <h2 className="mb-5 text-lg font-bold md:text-xl">
+                무엇을 체험하고 싶으신가요?
+              </h2>
+              <div className="flex gap-3">
+                <div className="flex h-[56px] w-full gap-2 rounded-[4px] border border-gray-700 px-3 py-4">
+                  <Image src={BedIcon} alt="search icon" />
+                  {keyword.length > 0 && (
+                    <p className="absolute left-16 top-[70px] w-[144px] bg-white text-center text-[18px] text-gray-700 md:top-[76px]">
+                      내가 원하는 체험은
+                    </p>
+                  )}
+                  <input
+                    className="bg-white text-[18px] placeholder:text-[18px] placeholder:text-gray-600 active:bg-white"
+                    name="keyword"
+                    value={keyword}
+                    placeholder="내가 원하는 체험은"
+                    onChange={(e) => setKeyword(e.target.value)}
+                  />
+                </div>
+                <button
+                  className="h-[56px] w-[96px] rounded-[4px] bg-primary text-lg font-bold text-white md:w-[136px]"
+                  onClick={handleSearch}
+                  name="name"
+                >
+                  검색하기
+                </button>
+              </div>
+            </div>
+          </Suspense>
         </section>
-        <section>
+        {content ? (
+          <SearchActivityResult />
+        ) : (
           <div>
-            <Suspense>
-              <ActivityCardList />
-            </Suspense>
+            <section>
+              <PopularActivityList />
+            </section>
+            <section className="container">
+              <Suspense>
+                <ActivityCardList />
+              </Suspense>
+            </section>
           </div>
-        </section>
+        )}
       </div>
     </>
   );
 }
+
+// @TODO 쿼리 스트링 뒤죽박죽 - 카테고리 변경하면 페이지 번호 따라옴 / 반응형 화면 size에 따른 페이지 번호 변경 적용 안됨
+// @TODO 검색 후 메인 페이지로 돌아와도 메인페이지 렌더링 안됨 - 초기화 필요 (keyword param이 삭제 안되고 null 적용됨)
+// @TODO 인기 체험 슬라이더 디자인 수정
+// @TODO 카테고리 mobile 화면일 때 슬라이더 적용

--- a/src/app/components/MainPage/ActivityCard.tsx
+++ b/src/app/components/MainPage/ActivityCard.tsx
@@ -3,6 +3,7 @@
 import { ActivityInfo } from "@customTypes/MainPage";
 import Image from "next/image";
 import Link from "next/link";
+import { formatPriceKorean } from "@utils/formatPrice";
 import icon_star from "@icons/icon_star_on.svg";
 
 interface ActivityCardProps {
@@ -39,7 +40,7 @@ const ActivityCard = ({
             </div>
             <div className="text-[18px] font-semibold md:text-2xl">{title}</div>
             <div className="text-xl font-bold md:text-[24px]">
-              {`₩ ${price} `}
+              {formatPriceKorean(price)}
               <span className="text-lg text-gray-800 md:text-xl">/ 인</span>
             </div>
           </div>

--- a/src/app/components/MainPage/PopularActivityCard.tsx
+++ b/src/app/components/MainPage/PopularActivityCard.tsx
@@ -1,6 +1,7 @@
 import { ActivityInfo } from "@customTypes/MainPage";
 import Image from "next/image";
 import Link from "next/link";
+import { formatPriceKorean } from "@utils/formatPrice";
 import icon_star from "@icons/icon_star_on.svg";
 
 interface PopularActivityCardProps {
@@ -12,10 +13,10 @@ const PopularActivityCard = ({
   return (
     <Link href={`/activities/${id}`}>
       <div
-        className="h-[186px] w-[186px] rounded-3xl bg-cover bg-center md:h-[384px] md:w-[384px]"
+        className="mx-3 h-[186px] w-[186px] rounded-3xl bg-cover bg-center md:h-[317px] md:w-[317px]"
         style={{ backgroundImage: `url('${bannerImageUrl}')` }}
       >
-        <div className="mb-6 ml-5 flex h-[160px] flex-col justify-end gap-[6px] text-white md:h-[340px]">
+        <div className="mb-6 ml-5 flex h-[160px] flex-col justify-end gap-[6px] text-white">
           <div className="flex">
             <Image
               src={icon_star}
@@ -29,7 +30,7 @@ const PopularActivityCard = ({
           </div>
           <div className="text-[18px] font-semibold md:text-3xl">{title}</div>
           <div className="text-lg font-bold md:text-xl">
-            {`₩ ${price} `}
+            {formatPriceKorean(price)}
             <span className="text-lg text-gray-400 md:text-xl">/ 인</span>
           </div>
         </div>

--- a/src/app/components/MainPage/PopularActivityList.tsx
+++ b/src/app/components/MainPage/PopularActivityList.tsx
@@ -39,7 +39,7 @@ const PopularActivityList = () => {
   };
 
   const settings = {
-    dots: true,
+    dots: false,
     infinite: true,
     slidesToShow: 3,
     slidesToScroll: 3,
@@ -54,6 +54,29 @@ const PopularActivityList = () => {
         <Image src={Arrow_Left} alt="left arrow" />
       </SlickButtonFix>
     ),
+    responsive: [
+      {
+        breakpoint: 1280,
+        settings: {
+          slidesToShow: 3,
+          slidesToScroll: 3,
+        },
+      },
+      {
+        breakpoint: 786,
+        settings: {
+          slidesToShow: 3,
+          slidesToScroll: 3,
+        },
+      },
+      {
+        breakpoint: 640,
+        settings: {
+          slidesToShow: 2,
+          slidesToScroll: 2,
+        },
+      },
+    ],
   };
 
   const { data } = usePopularData();
@@ -62,11 +85,11 @@ const PopularActivityList = () => {
   const popularActivities = activities.slice(0, 6);
 
   return (
-    <div className="md:mb-15 mb-10">
-      <h1 className="mb-4 text-[18px] font-bold md:mb-8 md:text-[36px]">
+    <div className="md:mb-15 mb-10 mt-32 md:mt-40">
+      <h1 className="container mb-4 text-[18px] font-bold md:mb-8 md:text-[36px]">
         🔥인기 체험
       </h1>
-      <div>
+      <div className="container">
         <Slider {...settings}>
           {popularActivities.map((activity) => (
             <PopularActivityCard key={activity.id} cardData={activity} />

--- a/src/app/components/MainPage/SearchActivityResult.tsx
+++ b/src/app/components/MainPage/SearchActivityResult.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import instance from "@api/axios";
+import { ActivityResponse } from "@customTypes/MainPage";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "next/navigation";
+import ActivityCard from "./ActivityCard";
+import Pagination from "./Pagination";
+import useOffsetSize from "@hooks/useOffsetSize";
+
+const getSearch = async (keyword: string, pageNum: number, size: number) => {
+  const params = new URLSearchParams({
+    method: "offset",
+    keyword,
+    page: String(pageNum + 1),
+    size: String(size),
+  });
+  const response = await instance.get<ActivityResponse>(
+    `/activities?${params}`,
+  );
+  return response.data;
+};
+const useSearch = (keyword: string, pageNum: number, size: number) => {
+  return useQuery({
+    queryKey: ["searchActivity", keyword, pageNum, size],
+    queryFn: () => getSearch(keyword, pageNum, size),
+    placeholderData: keepPreviousData,
+  });
+};
+
+const SearchActivityResult = () => {
+  const [currentPageNum, setCurrentPageNum] = useState(0);
+  const searchParams = useSearchParams();
+  const currentPageGroup = Math.floor(currentPageNum / 5);
+  const currentSize = useOffsetSize();
+  const keyword = searchParams.get("keyword");
+
+  const handlePageNum = (page: number) => {
+    setCurrentPageNum(page);
+  };
+
+  const { data } = useSearch(String(keyword), currentPageNum, currentSize);
+
+  const searchActivities = data?.activities || [];
+  const searchTotalCount = data?.totalCount || 0;
+  return (
+    <div className="container mt-40">
+      <div className="flex flex-col gap-3">
+        <h1 className="text-2xl md:text-3xl">
+          <span className="font-bold">{keyword}</span>으로 검색한 결과입니다.
+        </h1>
+        <p className="mb-6 text-lg">총 {searchTotalCount}개의 결과</p>
+      </div>
+      <div className="flex flex-col gap-[38px] md:gap-[72px] xl:gap-[64px]">
+        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+          {searchActivities.map((activity) => (
+            <ActivityCard key={activity.id} cardData={activity} />
+          ))}
+        </div>
+        {searchTotalCount === 0 && (
+          <div className="text-2xl">검색 결과가 없습니다.</div>
+        )}
+        {searchTotalCount !== 0 && (
+          <div className="mb-[83px] flex items-center justify-center">
+            <Pagination
+              totalCount={searchTotalCount}
+              currentGroup={currentPageGroup}
+              currentPage={currentPageNum}
+              offsetLimit={currentSize}
+              setPageNum={handlePageNum}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+export default SearchActivityResult;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="kr">
+    <html lang="ko">
       <body className="min-w-80 antialiased">
         <AuthProvider>
           <ReactQueryProvider>{children}</ReactQueryProvider>


### PR DESCRIPTION
<!-- PR 제목에 관련된 이슈 번호를 포함합니다 -->
<!-- 예시: Fix #23 - 프로젝트 규칙 논의 -->

## 관련 이슈 (Related Issues)
Feat #49 

## 변경 사항 (Changes)
<!-- 이 PR에서 어떤 부분이 변경되었는지 상세히 설명합니다. -->
- 아직 변경해야될 부분도 있고 수정할 게 많은데 멘토링 코드 리뷰를 받기 위해서 PR 올립니다!

## 구현 사항
#### 1. 메인 페이지 검색 기능 구현 Api - GET 체험 리스트 - 'keyword' 쿼리 이용
#### 2. 브라우저 URL에 page, category, sort, keyword 쿼리 보이도록 적용

## 수정 필요
### 1. 검색 후 헤더의 로고를 클릭시 메인 페이지 기존의 체험 리스트가 렌더링 되지 않습니다.
![수정1](https://github.com/user-attachments/assets/fec57f3e-01d4-4f19-af64-625f34e68ad9)

#### 예상 원인
- 로고를 클릭하면서 돌아가고자 할 때 GET 요청에서 keyword 쿼리가 사라져야 하는데 네트워크를 확인해보면 keyword=null로 적용되면서 검색 결과가 0이라는 화면이 렌더링됩니다.
- 새로고침을 누르면 그때서야 keyword 쿼리가 사라지고 메인화면이 제대로 렌더링됩니다.


### 2. 카테고리를 변경했을 때 이전에 있던 카테고리의 페이지 번호가 그대로 따라옵니다. 
![수정2](https://github.com/user-attachments/assets/7c285f44-3caa-4cac-9416-8ac8655af717)

#### 예상 원인
- 카테고리를 변경하면 api GET 요청에는 새로운 page 1 번호로 요청이 잘 가는데 브라우저의 url 쿼리 변경에 문제가 보입니다..
- 쿼리를 새로고침할 수 있는 로직이 필요한 것 같습니다.

### 3. 그 외 슬라이더 디자인에 수정이 필요합니다.
- 인기체험 슬라이더 디자인 수정 필요
- 카테고리 목록 슬라이더 적용 필요 (모바일 크기 화면에서..)


## 체크리스트 (Checklist)
<!-- PR을 완료하기 전에 확인해야 할 사항들을 체크리스트로 만듭니다. -->
- [ ] 코드가 제대로 동작하는지 테스트함
- [ ] 코드 컨벤션을 잘 지킴

## 리뷰어 참고 사항 (Notes for Reviewers)
<!-- 리뷰어가 참고해야 할 사항이나 리뷰 시 집중해야 할 부분을 적습니다. -->
- 내일 멘토링 시간에 질문이 필요해서 멘토링 전에 approve 해주시면 좋을 것 같습니다! 감사합니다! 
