### PR TITLE
Feat: #88 알림창 제작 - 보완 필요

### DIFF
--- a/src/app/components/Header/NotificationMenu.tsx
+++ b/src/app/components/Header/NotificationMenu.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
+import Notifications from "../Notification/Notifications";
 import { useDropdown } from "@hooks/useDropdown";
 import Notification from "@icons/icon_notification.svg";
 
@@ -14,16 +15,14 @@ export default function NotificationMenu() {
         <Image src={Notification} alt="알림" width={24} height={24} />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full z-10 mt-2 w-full min-w-40 rounded-lg border border-gray-400 bg-white">
+        <div className="absolute right-0 top-full z-10 mt-2 w-[368px] min-w-40 rounded-lg border border-gray-400 bg-[#CBD8D5] px-5 py-6 shadow-custom-shadow-01">
           <div
             className="py-1"
             role="menu"
             aria-orientation="vertical"
             aria-labelledby="options-menu"
           >
-            <div className="block px-4 py-2 text-sm text-gray-700">알림 1</div>
-            <div className="block px-4 py-2 text-sm text-gray-700">알림 2</div>
-            <div className="block px-4 py-2 text-sm text-gray-700">알림 3</div>
+            <Notifications close={close} />
           </div>
         </div>
       )}

--- a/src/app/components/Header/NotificationMenu.tsx
+++ b/src/app/components/Header/NotificationMenu.tsx
@@ -15,7 +15,7 @@ export default function NotificationMenu() {
         <Image src={Notification} alt="알림" width={24} height={24} />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full z-10 mt-2 w-[368px] min-w-40 rounded-lg border border-gray-400 bg-[#CBD8D5] px-5 py-6 shadow-custom-shadow-01">
+        <div className="fixed inset-0 z-10 rounded-lg border border-gray-400 bg-[#CBD8D5] px-5 py-6 shadow-custom-shadow-01 md:absolute md:bottom-auto md:left-auto md:right-0 md:top-full md:mt-2 md:w-[368px] md:min-w-40">
           <div
             className="py-1"
             role="menu"

--- a/src/app/components/MainPage/CategorySort.tsx
+++ b/src/app/components/MainPage/CategorySort.tsx
@@ -7,10 +7,6 @@ import icon_arrow_next from "@icons/icon_arrow_button.svg";
 import icon_arrow_prev from "@icons/icon_arrow_button_prev.svg";
 import icon_arrow_filter from "@icons/icon_arrow_filter.svg";
 
-interface WindowSize {
-  width: number;
-}
-
 interface CategorySortProps {
   onSetSort: (e: MouseEvent<HTMLButtonElement>) => void;
   onSetCategory: (e: MouseEvent<HTMLButtonElement>) => void;
@@ -28,19 +24,7 @@ const CategorySort = ({
   const changeSize = useOffsetSize(1, 2, 3);
   const [categoryState, setCategoryState] = useState(0);
   const categoryRef = useRef<HTMLDivElement>(null);
-  const [windowSize, setWindowSize] = useState<WindowSize>({
-    width: window.innerWidth,
-  });
 
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowSize({ width: window.innerWidth });
-    };
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
   const handleButtonClick = (value: number) => {
     const nextCategory = categoryState + value;
     if (nextCategory >= 0 && nextCategory <= changeSize) {

--- a/src/app/components/Notification/NotificationCard.tsx
+++ b/src/app/components/Notification/NotificationCard.tsx
@@ -24,7 +24,7 @@ const NotificationCard = ({
     mutationFn: deleteNotification,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["notificatioin"],
+        queryKey: ["notification"],
       });
     },
   });

--- a/src/app/components/Notification/NotificationCard.tsx
+++ b/src/app/components/Notification/NotificationCard.tsx
@@ -1,0 +1,66 @@
+import instance from "@api/axios";
+import { useMutation, QueryClient } from "@tanstack/react-query";
+import Image from "next/image";
+import useUpdatedAt from "@hooks/useUpdatedAt";
+import icon_X from "@icons/icon_x_medium_24px.svg";
+
+interface NotificationCardProp {
+  content: string;
+  updatedAt: string;
+  notificationId: number;
+}
+const deleteNotification = async (notificationId: number) => {
+  const response = await instance.delete(`/my-notifications/${notificationId}`);
+  return response.data;
+};
+
+const NotificationCard = ({
+  content,
+  updatedAt,
+  notificationId,
+}: NotificationCardProp) => {
+  const queryClient = new QueryClient();
+  const { mutate } = useMutation({
+    mutationFn: deleteNotification,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["notificatioin"],
+      });
+    },
+  });
+
+  const confirmOrDecline = content.slice(
+    content.length - 8,
+    content.length - 6,
+  );
+
+  const handleDeleteNotification = () => {
+    mutate(notificationId);
+  };
+
+  return (
+    <li className="rounded-[5px] bg-white px-3 py-4">
+      <div className="flex items-center justify-between">
+        <div
+          className={`${confirmOrDecline === "승인" ? "bg-blue-300" : "bg-red-100"} h-2 w-2 rounded-full bg-blue-300`}
+        ></div>
+        <button onClick={handleDeleteNotification}>
+          <Image src={icon_X} alt="delete notification" />
+        </button>
+      </div>
+      <div>
+        {content.split(confirmOrDecline)[0]}
+        <br />
+        <div
+          className={`${confirmOrDecline === "승인" ? "text-blue-300" : "text-red-100"} inline`}
+        >
+          {confirmOrDecline}
+        </div>
+        {content.split(confirmOrDecline)[1]}
+      </div>
+      <div className="text-gray-700">{useUpdatedAt(updatedAt)}</div>
+    </li>
+  );
+};
+
+export default NotificationCard;

--- a/src/app/components/Notification/Notifications.tsx
+++ b/src/app/components/Notification/Notifications.tsx
@@ -1,0 +1,69 @@
+import instance from "@api/axios";
+import { useQuery } from "@tanstack/react-query";
+import Image from "next/image";
+import NotificationCard from "./NotificationCard";
+import icon_X from "@icons/icon_x_40px.svg";
+
+interface NotificationsProp {
+  close: () => void;
+}
+const getNotification = async (size?: number, cursorId?: number | null) => {
+  const params = new URLSearchParams();
+  if (cursorId) params.append("cursorId", String(cursorId));
+  if (size) params.append("size", String(size));
+  const response = await instance.get<NotificationData>(
+    `/my-notifications?${params}`,
+  );
+  return response.data;
+};
+
+const useNotification = (size?: number, cursorId?: number | null) => {
+  return useQuery({
+    queryKey: ["notificatioin", size, cursorId],
+    queryFn: () => getNotification(size, cursorId),
+  });
+};
+
+const Notifications = ({ close }: NotificationsProp) => {
+  const { data } = useNotification();
+  const totalCount = data?.totalCount || 0;
+  const notifications = data?.notifications || [];
+
+  const handleButtonClose = () => {
+    close();
+  };
+
+  return (
+    <div>
+      {totalCount === 0 ? (
+        <div>알림이 없습니다.</div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="flex justify-between">
+            <div className="text-xl font-bold">알림 {totalCount}개</div>
+            <button onClick={handleButtonClose}>
+              <Image
+                src={icon_X}
+                alt="notification off"
+                width={30}
+                height={30}
+                style={{ width: 30, height: 30 }}
+              />
+            </button>
+          </div>
+          <ol className="flex flex-col gap-2">
+            {notifications.map((item) => (
+              <NotificationCard
+                key={item.id}
+                content={item.content}
+                updatedAt={item.updatedAt}
+                notificationId={item.id}
+              />
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+};
+export default Notifications;

--- a/src/app/components/Notification/Notifications.tsx
+++ b/src/app/components/Notification/Notifications.tsx
@@ -19,7 +19,7 @@ const getNotification = async (size?: number, cursorId?: number | null) => {
 
 const useNotification = (size?: number, cursorId?: number | null) => {
   return useQuery({
-    queryKey: ["notificatioin", size, cursorId],
+    queryKey: ["notification"],
     queryFn: () => getNotification(size, cursorId),
   });
 };
@@ -36,7 +36,18 @@ const Notifications = ({ close }: NotificationsProp) => {
   return (
     <div>
       {totalCount === 0 ? (
-        <div>알림이 없습니다.</div>
+        <div className="flex items-center justify-between">
+          <div className="text-lg">알림이 없습니다.</div>
+          <button onClick={handleButtonClose}>
+            <Image
+              src={icon_X}
+              alt="notification off"
+              width={30}
+              height={30}
+              style={{ width: 30, height: 30 }}
+            />
+          </button>
+        </div>
       ) : (
         <div className="flex flex-col gap-4">
           <div className="flex justify-between">

--- a/src/hooks/useUpdatedAt.tsx
+++ b/src/hooks/useUpdatedAt.tsx
@@ -1,0 +1,18 @@
+export default function useUpdatedAt(updatedAt: string) {
+  const start = new Date(updatedAt);
+  const end = new Date();
+
+  const second = Math.floor((end.getTime() - start.getTime()) / 1000);
+  if (second < 60) return "방금 전";
+
+  const minute = second / 60;
+  if (minute < 60) return `${Math.floor(minute)}분 전`;
+
+  const hour = minute / 60;
+  if (hour < 24) return `${Math.floor(hour)}시간 전`;
+
+  const day = hour / 24;
+  if (day < 7) return `${Math.floor(day)}일 전`;
+
+  return `${start.toLocaleDateString()}`;
+}

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,0 +1,15 @@
+interface Notifications {
+  id: number;
+  teamId: string;
+  userId: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+interface NotificationData {
+  totalCount: number;
+  notifications: Notifications[];
+  cursorId: number;
+}


### PR DESCRIPTION
<!-- PR 제목에 관련된 이슈 번호를 포함합니다 -->
<!-- 예시: Fix #23 - 프로젝트 규칙 논의 -->

## 관련 이슈 (Related Issues)
<!-- 이 PR이 해결하는 이슈 번호를 적습니다. -->
<!-- Closes, Fixes, Resolves 키워드를 사용합니다. -->
<!-- 예시: Fixes #23 -->
Feat #88 

## 변경 사항 (Changes)
<!-- 이 PR에서 어떤 부분이 변경되었는지 상세히 설명합니다. -->
- 알림창을 제작했습니다.
- 승인은 파란색 글씨로 나타나고 거절은 빨간색 글씨로 나타납니다!
- 알림이 0개일 때는 알림이 없다고 나타납니다.
- md 화면보다 작을 때는 화면전체에 알림창이 채워집니다. 
![image](https://github.com/user-attachments/assets/1c811808-2ab1-4d3d-9d8d-0f82674140e0)
![image](https://github.com/user-attachments/assets/b50ca215-37e5-410b-b93e-7793ac769333)


## 체크리스트 (Checklist)
<!-- PR을 완료하기 전에 확인해야 할 사항들을 체크리스트로 만듭니다. -->
- [x] 코드가 제대로 동작하는지 테스트함
- [x] 코드 컨벤션을 잘 지킴


## 추가 설명 (Additional Context)
<!-- 변경 사항 외에 추가로 필요한 설명이나 스크린샷 등을 첨부합니다. -->
- components 폴더에 Notification 폴더를 생성해서 작업했습니다.
- 알림에 X 버튼을 누르면 해당 알림을 useMutation으로 삭제합니다.
- 보완 필요: 알림을 삭제하면 바로 반영되지 않고 알림창을 다시 오픈하면 삭제되어있습니다. useMutation 쿼리 키를 맞춰줬는데도 해결되지 않았습니다..
- useUpdatedAt은 알림이 등록된 시간을 n분/ n시간 / n일 전으로 나타내는 훅입니다.

## 리뷰어 참고 사항 (Notes for Reviewers)
<!-- 리뷰어가 참고해야 할 사항이나 리뷰 시 집중해야 할 부분을 적습니다. -->
- useMutation 사용해서 알림 삭제할때 바로 반영되지 않는 부분에 대해서 아시는 분 조언 주시면 감사하겠습니다!!
